### PR TITLE
:sparkles: Add the ability to access authenticated GET endpoints.

### DIFF
--- a/bubbles.gemspec
+++ b/bubbles.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.1.4"
+  spec.add_development_dependency "bundler", "~> 2.2.26"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "minitest-reporters", "~> 1.1"

--- a/spec/bubbles/resources_spec.rb
+++ b/spec/bubbles/resources_spec.rb
@@ -76,6 +76,41 @@ describe Bubbles::Resources do
     end
   end
 
+  context 'when using the listmonk API' do
+    context 'when accessed using http' do
+      context 'when a GET request is used' do
+        before do
+          Bubbles.configure do |config|
+            config.environments = [{
+                                     scheme: 'http',
+                                     host: 'listmonk.example.com'
+                                   }]
+            config.endpoints = [
+              {
+                location: '/api/lists',
+                method: :get,
+                api_key_required: false,
+                authenticated: true,
+                encode_authorization: %i[username password],
+                name: "get_lists"
+              }
+            ]
+          end
+        end
+
+        it 'should return a 200 ok' do
+          VCR.use_cassette 'get_lists_authenticated' do
+            env = Bubbles::Resources.new.environment
+
+            # Use a dummy login and password
+            response = env.get_lists 'someone', '7162jahd89'
+            expect(response).to_not be_nil
+          end
+        end
+      end
+    end
+  end
+
   context 'when using a dummy manufactured API' do
     context 'when accessed using https' do
       context 'when accessed using a HEAD request' do

--- a/spec/fixtures/vcr_cassettes/get_lists_authenticated.yml
+++ b/spec/fixtures/vcr_cassettes/get_lists_authenticated.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://listmonk.example.com/api/lists
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.1p33
+      Authorization:
+      - Basic c29tZW9uZTo3MTYyamFoZDg5
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - listmonk.loonslanding.beer
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0 (Ubuntu)
+      Date:
+      - Tue, 28 Dec 2021 16:30:25 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '762'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - http://listmonk.loonslanding.beer:9916
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Authorization,Accept,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS,PUT,DELETE,PATCH
+    body:
+      encoding: UTF-8
+      string: '{"data":{"results":[{"id":3,"created_at":"2021-12-04T23:23:27.066656Z","updated_at":"2021-12-06T18:38:52.028697Z","uuid":"b8c458db-da5e-4cf7-a35e-927ac72ef5ca","name":"Vip
+        List","type":"private","optin":"single","tags":["vips"],"subscriber_count":30},{"id":4,"created_at":"2021-12-04T23:23:50.38752Z","updated_at":"2021-12-06T18:43:38.977883Z","uuid":"929b85f2-cd4d-4a69-8a01-884936f89a2f","name":"Newsletter
+        List","type":"private","optin":"double","tags":["subscribers"],"subscriber_count":47},{"id":6,"created_at":"2021-12-26T17:56:00.601191Z","updated_at":"2021-12-26T17:56:00.601191Z","uuid":"1a5eed6f-794e-4380-aa87-521d65e248a8","name":"Test
+        List","type":"private","optin":"single","tags":["test"],"subscriber_count":4}],"total":3,"per_page":20,"page":1}}
+
+        '
+    http_version: 
+  recorded_at: Tue, 28 Dec 2021 16:30:24 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
For some APIs, it is necessary to authenticate using a header (e.g.
Authorization: Bearer or Basic) in order to utilize the endpoint. This
commit adds support for authentication with GET endpoints.

Fixes #41.